### PR TITLE
Docs/material 6 2

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install --upgrade pip
-        pip install mkdocs mkdocs-material==5.0.0 pygments-bsl
+        pip install mkdocs mkdocs-material pygments-bsl
     
     - name: Dowload latest GitHub Pages
       run: |

--- a/docs/assets/javascripts/tables.js
+++ b/docs/assets/javascripts/tables.js
@@ -1,0 +1,6 @@
+app.document$.subscribe(function() {
+    var tables = document.querySelectorAll("article table")
+    tables.forEach(function(table) {
+        new Tablesort(table)
+    })
+})

--- a/docs/assets/stylesheets/extra.css
+++ b/docs/assets/stylesheets/extra.css
@@ -2,26 +2,10 @@
     margin-right: 0;
 }
 
-.md-sidebar--secondary {
-    margin-top: 220px;
-    margin-left: 0.5rem;
-}
-
-/* для отступа заголовка "Содержание" */
-.md-sidebar--secondary .md-nav__title {  
-    padding-left: 0px;
-}
-
 .md-typeset__table {
     padding: 0;
 }
 
 .md-typeset table:not([class]) {
     font-size: .54rem;
-}
-
-@media only screen and (min-width:59.9375em) and (max-width:80em) {
-    .md-sidebar--secondary {
-        display: none;
-    }
 }

--- a/mkdocs.en.yml
+++ b/mkdocs.en.yml
@@ -1,10 +1,36 @@
 site_name: BSL Language Server
 nav:
-  - Home: index.md
-  - Contributing: contributing/index.md
-  - Reporters: reporters/index.md
+  - Home:
+    - index.md
+    - faq.md
+    - systemRequirements.md
+  - Contributing:
+    - About: contributing/index.md
+    - Start:
+      - contributing/EnvironmentSetting.md
+      - contributing/FastStart.md
+      - contributing/StyleGuide.md
+      - JavaDoc: javadoc/index.html
+    - Diagnostics development:
+      - contributing/DiagnosticDevWorkFlow.md
+      - contributing/DiagnosticExample.md
+      - contributing/DiagnosticStructure.md
+      - contributing/DiagnosticTypeAndSeverity.md
+      - contributing/DiagnosticTag.md
+      - contributing/DiagnostcAddSettings.md
+      - contributing/DiagnosticQuickFix.md
+  - Reporters:
+    - About: reporters/index.md
+    - JSON: reporters/json.md
+    - Generic Issue: reporters/generic.md
+    - JUnit: reporters/junit.md
+    - TSLint: reporters/tslint.md
+    - Console: reporters/console.md
   - Diagnostics: diagnostics/index.md
-  - Features: features/index.md
+  - Features:
+    - About: features/index.md
+    - features/ConfigurationFile.md
+    - features/DiagnosticIgnorance.md
   - Russian: https://1c-syntax.github.io/bsl-language-server
 theme: 
   name: material
@@ -12,8 +38,14 @@ theme:
   logo: 'assets/images/logo.png'
   favicon: 'assets/images/logo.png'
   palette:
+    scheme: preference
     primary: 'white'
     accent: 'indigo'
+  features:
+    - navigation.tabs
+    - search.highlight
+    - toc.integrate
+    - header.autohide
 extra:
   social:
     - icon: fontawesome/brands/github
@@ -22,11 +54,16 @@ extra:
       link: 'https://t.me/bsl_language_server'
 extra_css:
   - 'assets/stylesheets/extra.css'
+extra_javascript:
+  - https://cdnjs.cloudflare.com/ajax/libs/tablesort/5.2.1/tablesort.min.js
+  - assets/javascripts/tables.js
 markdown_extensions:
   - admonition
   - codehilite
-  - toc:
-      permalink: Link
+  - markdown.extensions.toc:
+      permalink: true
+      slugify: !!python/name:pymdownx.slugs.uslugify_cased
+      toc_depth: 2
 
 plugins:
   - search:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,9 @@ extra:
       link: 'https://t.me/bsl_language_server'
 extra_css:
   - 'assets/stylesheets/extra.css'
+extra_javascript:
+  - https://cdnjs.cloudflare.com/ajax/libs/tablesort/5.2.1/tablesort.min.js
+  - assets/javascripts/tables.js
 markdown_extensions:
   - admonition
   - codehilite

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,8 @@ theme:
     scheme: preference
     primary: 'white'
     accent: 'indigo'
+  features:
+    - toc.integrate
 extra:
   social:
     - icon: fontawesome/brands/github

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ theme:
   logo: 'assets/images/logo.png'
   favicon: 'assets/images/logo.png'
   palette:
+    scheme: preference
     primary: 'white'
     accent: 'indigo'
 extra:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,8 +31,10 @@ extra_javascript:
 markdown_extensions:
   - admonition
   - codehilite
-  - toc:
+  - markdown.extensions.toc:
       permalink: true
+      slugify: !!python/name:pymdownx.slugs.uslugify_cased
+      toc_depth: 2
 
 plugins:
   - search:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,10 +1,36 @@
 site_name: BSL Language Server
 nav:
-  - Домашняя: index.md
-  - Руководство контрибьютора: contributing/index.md
-  - Репортеры: reporters/index.md
+  - Домашняя:
+    - index.md
+    - faq.md
+    - systemRequirements.md
+  - Руководство контрибьютора:
+    - О разделе: contributing/index.md
+    - Старт:
+      - contributing/EnvironmentSetting.md
+      - contributing/FastStart.md
+      - contributing/StyleGuide.md
+      - JavaDoc: javadoc/index.html
+    - Разработка диагностик:
+      - contributing/DiagnosticDevWorkFlow.md
+      - contributing/DiagnosticExample.md
+      - contributing/DiagnosticStructure.md
+      - contributing/DiagnosticTypeAndSeverity.md
+      - contributing/DiagnosticTag.md
+      - contributing/DiagnostcAddSettings.md
+      - contributing/DiagnosticQuickFix.md
+  - Репортеры:
+    - О разделе: reporters/index.md
+    - JSON: reporters/json.md
+    - Generic Issue: reporters/generic.md
+    - JUnit: reporters/junit.md
+    - TSLint: reporters/tslint.md
+    - Console: reporters/console.md
   - Диагностики: diagnostics/index.md
-  - Дополнительные возможности: features/index.md
+  - Дополнительные возможности:
+    - О разделе: features/index.md
+    - features/ConfigurationFile.md
+    - features/DiagnosticIgnorance.md
   - English: https://1c-syntax.github.io/bsl-language-server/en
 theme: 
   name: material
@@ -16,7 +42,10 @@ theme:
     primary: 'white'
     accent: 'indigo'
   features:
+    - navigation.tabs
+    - search.highlight
     - toc.integrate
+    - header.autohide
 extra:
   social:
     - icon: fontawesome/brands/github


### PR DESCRIPTION
1. Теперь светлая или темная тема подъезжает в рамках параметров хрома (или винды)
2. Оглавление теперь отображается инлайн в содержании
3. Для нормального отображения пришлось сделать главное меню табами
4. Вроде б починился поиск. Раньше он работал хреного
5. Якоря на оглавления теперь генерируются с учетом кириллицы
6. В таблицах теперь есть сортировка при клике по заголовку